### PR TITLE
Add click-to-fix CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ web-interact screenshot --annotate # screenshot with numbered overlays
 | **Settings** | `set viewport/geo/offline/media/headers` |
 | **Low-level** | `mouse move/click/down/up/wheel`, `keyboard type/insert/press/down/up` |
 | **Console** | `console` (JS errors, warnings, logs) |
+| **Inspect** | `click-to-fix` (click element → trace to source code) |
 | **Config** | `mode default/assistant`, `browser-mode auto/real/sandbox` |
 | **Manage** | `status`, `browsers`, `close`, `stop`, `install` |
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -54,6 +54,23 @@ pub const ANNOTATE_SCREENSHOT_JS: &str = r#"await (async () => {
   }
 })()"#;
 
+/// JS injected into the page to create a visual inspector overlay.
+/// User hovers to see component names + source files, clicks to capture.
+/// Result stored in window.__clickToFixResult. Extracts React (_debugSource),
+/// Vue (__file), Svelte (__svelte_meta), Angular (ng.getComponent) metadata.
+/// Credit: Edoardo Re (github.com/edoardorex)
+const CLICK_TO_FIX_INJECT_JS: &str = r#"
+if(window.__clickToFixActive)return 'already active';
+var overlay=document.createElement('div');overlay.id='__ctf-overlay';overlay.style.cssText='position:fixed;top:0;left:0;width:100%;height:100%;z-index:2147483646;cursor:crosshair;';document.body.appendChild(overlay);
+var highlight=document.createElement('div');highlight.id='__ctf-highlight';highlight.style.cssText='position:fixed;border:2px solid #6366f1;background:rgba(99,102,241,0.08);pointer-events:none;z-index:2147483645;display:none;border-radius:3px;transition:all 0.05s ease;';document.body.appendChild(highlight);
+var label=document.createElement('div');label.id='__ctf-label';label.style.cssText='position:fixed;background:#6366f1;color:#fff;font:bold 11px/1.4 ui-monospace,monospace;padding:2px 8px;border-radius:4px;z-index:2147483647;pointer-events:none;display:none;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,0.15);';document.body.appendChild(label);
+var banner=document.createElement('div');banner.id='__ctf-banner';banner.style.cssText='position:fixed;top:0;left:0;right:0;background:#6366f1;color:#fff;font:bold 14px/1 system-ui,sans-serif;padding:10px 16px;z-index:2147483647;text-align:center;pointer-events:none;';banner.textContent='INSPECT MODE \u2014 Click any element to trace its source code';document.body.appendChild(banner);
+function getSourceInfo(el){var result={tag:el.tagName.toLowerCase(),id:el.id||null,classes:Array.from(el.classList),text:(el.textContent||'').trim().substring(0,120),attributes:{},source:null,component:null,outerSnippet:el.outerHTML.substring(0,300)};for(var i=0;i<el.attributes.length;i++){var a=el.attributes[i];if(a.name.startsWith('data-')||a.name==='aria-label'||a.name==='role'||a.name==='name'||a.name==='placeholder'||a.name==='type'||a.name==='href')result.attributes[a.name]=a.value}var fiber=null;var keys=Object.getOwnPropertyNames(el);for(var j=0;j<keys.length;j++){if(keys[j].startsWith('__reactFiber$')||keys[j].startsWith('__reactInternalInstance$')){fiber=el[keys[j]];break}}if(fiber){var current=fiber;while(current){if(current._debugSource){result.source={file:current._debugSource.fileName,line:current._debugSource.lineNumber,column:current._debugSource.columnNumber};if(current.type){result.component=typeof current.type==='string'?current.type:(current.type.displayName||current.type.name||null)}break}current=current.return||null}if(!result.component){var c=fiber;while(c){if(c.type&&typeof c.type==='function'){result.component=c.type.displayName||c.type.name||null;if(result.component)break}c=c.return||null}}}if(!result.source){var ve=el;while(ve){if(ve.__vueParentComponent){var comp=ve.__vueParentComponent;result.component=(comp.type&&(comp.type.name||comp.type.__name))||null;if(comp.type&&comp.type.__file)result.source={file:comp.type.__file,line:null,column:null};break}ve=ve.parentElement}}if(!result.source){var se=el;while(se){if(se.__svelte_meta){var meta=se.__svelte_meta;result.source={file:(meta.loc&&meta.loc.file)||null,line:(meta.loc&&meta.loc.line)||null,column:(meta.loc&&meta.loc.column)||null};var fn=meta.loc&&meta.loc.file;result.component=fn?fn.split('/').pop().replace('.svelte',''):null;break}se=se.parentElement}}if(!result.source){try{if(typeof ng!=='undefined'&&ng.getComponent){var ac=ng.getComponent(el);if(ac)result.component=(ac.constructor&&ac.constructor.name)||null}}catch(e){}}return result}
+overlay.addEventListener('mousemove',function(e){overlay.style.pointerEvents='none';var target=document.elementFromPoint(e.clientX,e.clientY);overlay.style.pointerEvents='';if(!target||target.id==='__ctf-overlay'||target.id==='__ctf-highlight'||target.id==='__ctf-label'||target.id==='__ctf-banner')return;var rect=target.getBoundingClientRect();highlight.style.display='block';highlight.style.top=rect.top+'px';highlight.style.left=rect.left+'px';highlight.style.width=rect.width+'px';highlight.style.height=rect.height+'px';var info=getSourceInfo(target);var txt=info.component||info.tag;if(info.source&&info.source.file){var short=info.source.file.split('/').slice(-2).join('/');txt+=' \u2190 '+short;if(info.source.line)txt+=':'+info.source.line}label.style.display='block';label.style.top=Math.max(0,rect.top-24)+'px';label.style.left=rect.left+'px';label.textContent=txt});
+overlay.addEventListener('click',function(e){e.preventDefault();e.stopPropagation();overlay.style.pointerEvents='none';var target=document.elementFromPoint(e.clientX,e.clientY);overlay.style.pointerEvents='';var info=getSourceInfo(target||document.body);window.__clickToFixResult=info;overlay.remove();highlight.remove();label.remove();document.getElementById('__ctf-banner')?.remove();window.__clickToFixActive=false});
+window.__clickToFixActive=true;
+"#;
+
 #[derive(Subcommand)]
 pub enum ActionCommand {
     #[command(about = "Run a script file against the browser")]
@@ -348,6 +365,12 @@ pub enum ActionCommand {
     BrowserMode {
         #[arg(help = "Mode: 'auto', 'real' (your running browser), or 'sandbox' (managed)")]
         target: Option<String>,
+    },
+
+    #[command(name = "click-to-fix", about = "Click any browser element to trace it to its source code")]
+    ClickToFix {
+        #[arg(long, default_value = "default", help = "Named page to use")]
+        page: String,
     },
 
     #[command(about = "Install the browser runtime and headless Chromium")]
@@ -798,6 +821,16 @@ console.log(result.serialized);"#,
             } else {
                 String::new()
             }
+        )),
+
+        ActionCommand::ClickToFix { page } => Some(format!(
+            r#"const page = await browser.getPage({page});
+await page.evaluate(() => {{ window.__clickToFixResult = undefined; }});
+await page.evaluate(() => {{ {CLICK_TO_FIX_INJECT_JS} }});
+await page.waitForFunction(() => window.__clickToFixResult !== undefined, {{ timeout: 120000 }});
+const result = await page.evaluate(() => JSON.stringify(window.__clickToFixResult));
+console.log(result);"#,
+            page = js_str(page),
         )),
 
         ActionCommand::Click { target, page } => Some(format!("{ACTION_CHECK}\n{}", gen_action_by_target(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -384,11 +384,17 @@ fn run() -> Result<i32, Box<dyn Error>> {
 fn run_script(cli: &Cli, script: String) -> Result<i32, Box<dyn Error>> {
     ensure_daemon()?;
 
-    let timeout_ms = u64::from(cli.timeout)
-        .checked_mul(1_000)
-        .ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "Timeout value is too large")
-        })?;
+    // click-to-fix needs 130s (user interacts with inspector for up to 2 min)
+    let is_click_to_fix = matches!(&cli.command, Some(ActionCommand::ClickToFix { .. }));
+    let timeout_ms = if is_click_to_fix {
+        130_000
+    } else {
+        u64::from(cli.timeout)
+            .checked_mul(1_000)
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "Timeout value is too large")
+            })?
+    };
 
     let exit_code = send_execute(cli, &script, timeout_ms)?;
 


### PR DESCRIPTION
## Summary
- New `click-to-fix` command: injects visual inspector overlay, user clicks element, returns source metadata as JSON
- Supports React (`_debugSource`), Vue (`__file`), Svelte (`__svelte_meta`), Angular (`ng.getComponent`)
- Timeout overridden to 130s (user interacts with browser)
- Respects browser-mode (auto-connects when mode is `real`)
- Inspector JS credit: @edoardorex

## Test plan
- [ ] `web-interact click-to-fix --help` shows correct usage
- [ ] Open a React dev app, run `click-to-fix`, verify inspector overlay appears
- [ ] Click an element, verify JSON with source.file and component returned
- [ ] Verify 2-minute timeout if user doesn't click
- [ ] 89 tests pass